### PR TITLE
Fedora rawhide check

### DIFF
--- a/.github/workflows/fedora-repos.yml
+++ b/.github/workflows/fedora-repos.yml
@@ -18,3 +18,6 @@ jobs:
         # note: we only compare double digit keys not to be concerned with some of the historical cruft
         run: |
           diff -u <(ls -1 fedora-repos/RPM-GPG-KEY-fedora-??-primary | xargs -n 1 basename) <(ls -1 keys/fedora/RPM-GPG-KEY-fedora-??-primary | xargs -n 1 basename)
+      - name: Check rawhide key points to correct release key
+        run: |
+          diff -u <(awk '$1 == "%global" && $2 == "rawhide_release" { print "RPM-GPG-KEY-fedora-"$3"-primary" }' fedora-repos/fedora-repos.spec) <(readlink keys/fedora/RPM-GPG-KEY-fedora-rawhide-primary)

--- a/check-fedora-rawhide.sh
+++ b/check-fedora-rawhide.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+#
+# Check and update Fedora Rawhide release version
+# Requires fedora-repos-rawhide installed
+
+PKG=fedora-gpg-keys
+
+key_path() {
+	echo "keys/fedora/RPM-GPG-KEY-fedora-$1-primary"
+}
+
+check_path() {
+	local NAME="$1"
+	local VERSION="$2"
+
+	NAME_PATH="$(key_path $NAME)"
+	RELEASE_PATH="$(key_path $VERSION)"
+
+	if [ "$(realpath "$NAME_PATH")" = "$(realpath "$RELEASE_PATH")" ]; then
+		echo "Fedora $NAME key is up-to-date"
+	else
+		rm -f "$NAME_PATH"
+		echo "Fedora $NAME key needs change: $RELEASE_PATH"
+		ln -vs "$(basename -- "$RELEASE_PATH")" "$NAME_PATH"
+	fi
+}
+
+PKG_VER=$(dnf --repo=rawhide repoquery -q fedora-gpg-keys)
+if [ $? -ne 0 ]; then
+	echo "Failed to fetch keys"
+	exit 1
+fi
+VER=$(echo "${PKG_VER#$PKG}" | cut -d- -f2 | cut -d: -f2)
+
+echo "Current Rawhide is release $VER"
+
+check_path rawhide $VER
+check_path rawhide+1 $((VER+1))
+check_path rawhide-1 $((VER-1))

--- a/check-fedora-rawhide.sh
+++ b/check-fedora-rawhide.sh
@@ -37,3 +37,4 @@ echo "Current Rawhide is release $VER"
 check_path rawhide $VER
 check_path rawhide+1 $((VER+1))
 check_path rawhide-1 $((VER-1))
+check_path rawhide-2 $((VER-2))

--- a/keys/fedora/RPM-GPG-KEY-fedora-rawhide+1-primary
+++ b/keys/fedora/RPM-GPG-KEY-fedora-rawhide+1-primary
@@ -1,0 +1,1 @@
+RPM-GPG-KEY-fedora-43-primary

--- a/keys/fedora/RPM-GPG-KEY-fedora-rawhide-1-primary
+++ b/keys/fedora/RPM-GPG-KEY-fedora-rawhide-1-primary
@@ -1,0 +1,1 @@
+RPM-GPG-KEY-fedora-41-primary

--- a/keys/fedora/RPM-GPG-KEY-fedora-rawhide-2-primary
+++ b/keys/fedora/RPM-GPG-KEY-fedora-rawhide-2-primary
@@ -1,0 +1,1 @@
+RPM-GPG-KEY-fedora-40-primary


### PR DESCRIPTION
This is attempt to reduce number of packages, which need to be updated after new release is branched from current rawhide.  This were initiated by broken mock during branching, because updates were needed together in two separate components:

- https://bodhi.fedoraproject.org/updates/FEDORA-2024-1a79132182
- https://bodhi.fedoraproject.org/updates/FEDORA-2024-be19a8b7dd

I think that is in fact not necessary, because mock-core-configs uses releasever only to compute key path one higher and one lower than current rawhide. If that is provided directly by this package, then mock-core-config can use symlink provided and change only when they want to add new release into collection. This package update would fix also mock rawhide.